### PR TITLE
make PythonHelper.scala serializable

### DIFF
--- a/src/main/scala/pyspark_cassandra/PythonHelper.scala
+++ b/src/main/scala/pyspark_cassandra/PythonHelper.scala
@@ -29,7 +29,8 @@ import pyspark_cassandra.Utils._
 import pyspark_util.Conversions._
 import pyspark_util.Pickling._
 
-class PythonHelper() {
+@SerialVersionUID(1L)
+class PythonHelper() extends Serializable {
   TypeConverter.registerConverter(UnpickledUUIDConverter)
   implicit val pickling = new Pickling()
 


### PR DESCRIPTION
I was using pyspark_cassandra with a streaming spark application and applying joinWithCassandraTable which apparently uses this class. So when doing checkpoints it wanted to serialize the dstream and its transformations and threw NonSerializable exception, so this fixes it