### PR TITLE
Implementation of append/add/overwrite/prepend/remove as a dictionary in python interface

### DIFF
--- a/README.md
+++ b/README.md
@@ -209,8 +209,14 @@ PySpark Cassandra supports saving arbitrary RDD's to Cassandra using:
 RDD is expected to contain dicts with keys mapping to CQL columns. Additional 
 arguments which can be supplied are:
 
-  * ``columns(iterable)``: The columns to save, i.e. which keys to take from the
-   dicts in the RDD.
+  * ``columns(iterable)``: The columns to save, i.e. which keys to take from the dicts in the RDD.
+    * ``array``: list of columns to be saved with default behaviour (overwrite)
+    * ``dictionary``: list of columns (keys) and cassandra collections modify operation to perform (values)  
+    -``""`` : emulate 'array' default behaviour. to be used for non-collection fields  
+    -``"append" | "add"`` : append to a collection (lists, sets, maps)  
+    -``"prepend"`` : prepend to a collection (lists)  
+    -``"remove"`` : remove from a collection (lists, sets)  
+    -``"overwrite"`` : overwrite a collection (lists, sets, maps)  
   * ``batch_size(int)``: The size in bytes to batch up in an unlogged batch of 
   CQL inserts.
   * ``batch_buffer_size(int)``: The maximum number of batches which are 
@@ -320,6 +326,23 @@ rdd.saveToCassandra(
 	"table",
 	ttl=timedelta(hours=1),
 )
+```
+
+Modify CQL collections::
+
+```python
+
+# Cassandra test table schema
+# create table test (user_id text, city text,  test_set set<text>, test_list list<text>, test_map map<text,text>, PRIMARY KEY (user_id));
+
+rdd = sc.parallelize([{"user_id":"123","city":"berlin","test_set":["a"],"test_list":["a"],"test_map":{"a":"1"}}])
+
+rdd.saveToCassandra("ks","test")
+
+rdd = sc.parallelize([{"user_id":"123","city":"berlin","test_set":["a"],"test_list":["b"],"test_map":{"b":"2"}}])
+
+rdd.saveToCassandra("ks","test", {"user_id":"", "city":"", "test_set":"remove", "test_list":"prepend", "test_map":"append"})
+
 ```
 
 Create a streaming context, convert every line to a generater of words which 

--- a/python/pyspark_cassandra/rdd.py
+++ b/python/pyspark_cassandra/rdd.py
@@ -78,9 +78,15 @@ def saveToCassandra(rdd, keyspace=None, table=None, columns=None,
     # create write config as map
     write_conf = WriteConf.build(write_conf, **write_conf_kwargs)
     write_conf = as_java_object(rdd.ctx._gateway, write_conf.settings())
-    # convert the columns to a string array
-    columns = as_java_array(rdd.ctx._gateway, "String",
-                            columns) if columns else None
+
+    if isinstance(columns, dict):
+        # convert the columns to a map where the value is the
+        # action inside Cassandra
+        columns = as_java_object(rdd.ctx._gateway, columns) if columns else None
+    else:
+        # convert the columns to a string array
+        columns = as_java_array(rdd.ctx._gateway, "String",
+                                columns) if columns else None
 
     helper(rdd.ctx) \
         .saveToCassandra(

--- a/src/main/scala/pyspark_cassandra/PythonHelper.scala
+++ b/src/main/scala/pyspark_cassandra/PythonHelper.scala
@@ -74,6 +74,16 @@ class PythonHelper() extends Serializable {
 
   /* rdds ------------------------------------------------------------------ */
 
+  def saveToCassandra(rdd: JavaRDD[Array[Byte]], keyspace: String, table: String, columns: JMap[String, String],
+                      rowFormat: Integer, keyed: Boolean, writeConf: JMap[String, Any]) = {
+
+    val selectedColumns = columnSelector(columns)
+    val conf = parseWriteConf(Some(writeConf))
+
+    implicit val rwf = new GenericRowWriterFactory(Format(rowFormat), asBooleanOption(keyed))
+    rdd.rdd.unpickle().saveToCassandra(keyspace, table, selectedColumns, conf)
+  }
+
   def saveToCassandra(rdd: JavaRDD[Array[Byte]], keyspace: String, table: String, columns: Array[String],
                       rowFormat: Integer, keyed: Boolean, writeConf: JMap[String, Any]) = {
 

--- a/src/main/scala/pyspark_cassandra/Utils.scala
+++ b/src/main/scala/pyspark_cassandra/Utils.scala
@@ -25,6 +25,26 @@ import org.apache.spark.SparkContext
 import scala.collection.JavaConversions._
 
 object Utils {
+
+  def columnSelector(columns: JMap[String, String]) = {
+
+    if (columns != null && ! columns.isEmpty()) {
+      SomeColumns(mapAsScalaMap(columns).toList.map(entry => (entry._1, entry._2) match {
+        case (key, "append") => CollectionColumnName(key, None, CollectionAppend)
+        case (key, "add") => CollectionColumnName(key, None, CollectionAppend)
+        case (key, "overwrite") => CollectionColumnName(key, None, CollectionOverwrite)
+        case (key, "prepend") => CollectionColumnName(key, None, CollectionPrepend)
+        case (key, "remove") => CollectionColumnName(key, None, CollectionRemove)
+        case (key, "") => ColumnName(key)
+        case (key, _) => throw new IllegalArgumentException("The only possible values are: " +
+          "append/add/overwrite/prepend/remove or empty")
+      }): _*)
+
+    } else {
+      AllColumns
+    }
+  }
+
   def columnSelector(columns: Array[String], default: ColumnSelector = AllColumns) = {
     if (columns != null && columns.length > 0) {
       SomeColumns(columns.map {


### PR DESCRIPTION
Hello @anguenot 

We are Nicolás Sarfati (@nsarfati), Emanuele Bardelli (@manu-olx) and Eli Romm (@elirommolx) working for OLX.

We found your Cassandra connector python port super interesting but for our job we were needing to use some functions that currently are provided by the Scala implementation, like the append/add/prepend/etc.

So, we added them into your currently port, receiving in the saveToCassandra function a map with the expected operation and for avoid issues with people that is currently using it, we are checking the instance, if it's a map we execute the new implementation, otherwise we still using the original calls.

I hope you found this code relevant and you would merge it and distribute the new version!

For any question that you may have don't hesitate to contact me or Emanuele.

Best regards.