### PR TITLE
avoid exceptions for empty lists

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -14,7 +14,7 @@ licenses += "Apache-2.0" -> url("http://opensource.org/licenses/Apache-2.0")
 
 libraryDependencies ++= Seq(
   "com.datastax.spark" %% "spark-cassandra-connector" % "2.3.0",
-  "net.razorvine" % "pyrolite" % "4.10"
+  "net.razorvine" % "pyrolite" % "4.20"
 )
 
 spName := "anguenot/pyspark-cassandra"

--- a/python/pyspark_cassandra/tests.py
+++ b/python/pyspark_cassandra/tests.py
@@ -143,6 +143,9 @@ class CollectionTypesTest(CassandraTestCase):
         'm': 'map<text, text>',
         'l': 'list<text>',
         's': 'set<text>',
+        'fm': 'frozen<map<text, text>>',
+        'fl': 'frozen<list<text>>',
+        'fs': 'frozen<set<text>>',
     }
 
     @classmethod
@@ -198,6 +201,22 @@ class CollectionTypesTest(CassandraTestCase):
         maps = {'s%s' % i: set(string.ascii_lowercase[:i]) for i in
                 range(1, 10)}
         self.collections_common_tests(maps, 's')
+
+    def test_frozen_list(self):
+        lists = {'fl%s' % i: list(string.ascii_lowercase[:i]) for i in
+                 range(0, 10)}
+        self.collections_common_tests(lists, 'fl')
+
+    def test_frozen_map(self):
+        maps = {
+            'fm%s' % i: {k: 'x' for k in string.ascii_lowercase[:i]} for i in
+            range(0, 10)}
+        self.collections_common_tests(maps, 'fm')
+
+    def test_frozen_set(self):
+        maps = {'fs%s' % i: set(string.ascii_lowercase[:i]) for i in
+                range(0, 10)}
+        self.collections_common_tests(maps, 'fs')
 
     def collections_operations_tests(self, before, update, key,
                                      column, operation):

--- a/src/main/scala/pyspark_util/Pickling.scala
+++ b/src/main/scala/pyspark_util/Pickling.scala
@@ -65,6 +65,7 @@ class Pickling extends Serializable {
     Pickler.registerCustomPickler(Class.forName("java.nio.HeapByteBuffer"), ByteBufferPickler)
     Pickler.registerCustomPickler(classOf[GatheredByteBuffers], GatheringByteBufferPickler)
     Pickler.registerCustomPickler(Class.forName("scala.collection.immutable.$colon$colon"), ListPickler)
+    Pickler.registerCustomPickler(classOf[List[_]], ListPickler)
     Pickler.registerCustomPickler(classOf[ArraySeq[_]], ListPickler)
     Pickler.registerCustomPickler(classOf[Buffer[_]], ListPickler)
     Pickler.registerCustomPickler(classOf[WrappedArray.ofRef[_]], ListPickler)

--- a/src/main/scala/pyspark_util/Pickling.scala
+++ b/src/main/scala/pyspark_util/Pickling.scala
@@ -102,6 +102,7 @@ class Pickling extends Serializable {
     Pickler.registerCustomPickler(classOf[Set.Set4[_]], ListPickler)
     Pickler.registerCustomPickler(classOf[HashSet1[_]], ListPickler)
     Pickler.registerCustomPickler(classOf[HashTrieSet[_]], ListPickler)
+    Pickler.registerCustomPickler(classOf[Map[_, _]], MapPickler)
     Pickler.registerCustomPickler(classOf[WithDefault[_, _]], MapPickler)
     Pickler.registerCustomPickler(classOf[Map1[_, _]], MapPickler)
     Pickler.registerCustomPickler(classOf[Map2[_, _]], MapPickler)


### PR DESCRIPTION
- convert scala lists to java lists when pickling
- update pyrolite to latest version

fixes #37 