### PR TITLE
pyspark-cassandra: add ignoreNulls option to WriteConf

### DIFF
--- a/python/pyspark_cassandra/conf.py
+++ b/python/pyspark_cassandra/conf.py
@@ -54,7 +54,7 @@ class WriteConf(_Conf):
                  batch_grouping_key=None,
                  consistency_level=None, parallelism_level=None,
                  throughput_mibps=None, ttl=None,
-                 timestamp=None, metrics_enabled=None):
+                 timestamp=None, metrics_enabled=None, ignore_nulls=None):
         """
             @param batch_size(int):
                 The size in bytes to batch up in an unlogged batch of CQL
@@ -88,6 +88,8 @@ class WriteConf(_Conf):
                 If None given the Cassandra nodes determine the timestamp.
             @param metrics_enabled(bool):
                 Whether to enable task metrics updates.
+            @param ignore_nulls(bool):
+                Whether to ignore nulls when upserting null values
         """
         self.batch_size = batch_size
         self.batch_buffer_size = batch_buffer_size
@@ -112,3 +114,4 @@ class WriteConf(_Conf):
         self.timestamp = timestamp
 
         self.metrics_enabled = metrics_enabled
+        self.ignore_nulls = ignore_nulls

--- a/python/tests.py
+++ b/python/tests.py
@@ -576,6 +576,7 @@ class ConfTest(SimpleTypesTestBase):
         save(timestamp=datetime.now())
         save(metrics_enabled=True)
         save(write_conf=WriteConf(ttl=3, metrics_enabled=True))
+        save(ignore_nulls=True)
 
 
 class StreamingTest(SimpleTypesTestBase):

--- a/src/main/scala/pyspark_cassandra/Utils.scala
+++ b/src/main/scala/pyspark_cassandra/Utils.scala
@@ -95,6 +95,7 @@ object Utils {
             case ("ttl", v: Int) => conf = conf.copy(ttl = TTLOption.constant(v))
             case ("timestamp", v: Number) => conf = conf.copy(timestamp = TimestampOption.constant(v.longValue()))
             case ("metrics_enabled", v: Boolean) => conf = conf.copy(taskMetricsEnabled = v)
+            case ("ignore_nulls", v: Boolean) => conf = conf.copy(ignoreNulls = v)
             case _ => throw new IllegalArgumentException(s"Write conf key $k with value $v unsupported")
           }
         }


### PR DESCRIPTION
This adds the ignoreNulls option available in DataStax Spark-Cassandra Connector (https://github.com/datastax/spark-cassandra-connector/blob/master/doc/5_saving.md#globally-treating-all-nulls-as-unset) to the WriteConf in pyspark-cassandra.
This allows users to unset null values when upserting data into Cassandra.